### PR TITLE
Fix/task detail ime padding

### DIFF
--- a/tasks/presentation/src/main/java/com/mhss/app/presentation/TaskDetailScreen.kt
+++ b/tasks/presentation/src/main/java/com/mhss/app/presentation/TaskDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -182,7 +183,7 @@ fun TaskDetailScreen(
         }
     ) { paddingValues ->
         TaskDetailsContent(
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier.padding(paddingValues).imePadding(),
             completed = completed,
             title = title,
             description = description,


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

Added .imePadding() applied to TaskDetailsContent modifier in TaskDetailScreen. When keyboard opens, bottom padding expands equal to IME height, and scroll area stays accessible above keyboard.

Fixes #363 
Simple QOL / bug fix where the keyboard isn't considered in scroll padding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style (formatting, new lines, etc.)
- [ ] Refactoring (no functional changes, renaming)
- [ ] Other (describe the changes):

## Checklist:

- [x] The PR is to the `dev` branch
- [x] My code follows the style and architecture of the project
- [x] I have performed a self-review of my code
- [x] I have tested the app on an actual Android device and everything works as expected
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas (no, but change is very simple)
