### PR TITLE
Fix/multi day event rendering

### DIFF
--- a/calendar/domain/src/main/java/com/mhss/app/domain/use_case/GetMonthEventsUseCase.kt
+++ b/calendar/domain/src/main/java/com/mhss/app/domain/use_case/GetMonthEventsUseCase.kt
@@ -2,21 +2,26 @@ package com.mhss.app.domain.use_case
 
 import com.mhss.app.domain.MONTH_GRID_CELL_COUNT
 import com.mhss.app.domain.model.CalendarDay
+import com.mhss.app.domain.model.CalendarEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.YearMonth
 import kotlinx.datetime.atTime
+import kotlinx.datetime.daysUntil
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
 import org.koin.core.annotation.Factory
 import org.koin.core.annotation.Named
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
-private const val MILLIS_PER_DAY = 24 * 60 * 60 * 1000L
-
+@OptIn(ExperimentalTime::class)
 @Factory
 class GetMonthEventsUseCase(
     private val getEventsWithinRangeUseCase: GetEventsWithinRangeUseCase,
@@ -28,23 +33,43 @@ class GetMonthEventsUseCase(
         firstDayOfWeek: DayOfWeek = DayOfWeek.SUNDAY
     ): List<CalendarDay> {
         return withContext(defaultDispatcher) {
+            val tz = TimeZone.currentSystemDefault()
             val firstOfMonth = month.firstDay
             val startOffset = firstOfMonth.dayOfWeek.dayNumberFrom(firstDayOfWeek)
             val startDate = firstOfMonth.minus(startOffset, DateTimeUnit.DAY)
 
-            val gridDays = MONTH_GRID_CELL_COUNT.toLong()
-            val endDate = startDate.plus(gridDays, DateTimeUnit.DAY)
+            val gridDays = MONTH_GRID_CELL_COUNT
+            val endDate = startDate.plus(gridDays.toLong(), DateTimeUnit.DAY)
 
-            val startMillis = startDate.atTime(hour = 0, minute = 0).toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
-            val endMillis = endDate.atTime(hour = 23, minute = 59).toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
+            val startMillis = startDate.atTime(hour = 0, minute = 0).toInstant(tz).toEpochMilliseconds()
+            val endMillis = endDate.atTime(hour = 23, minute = 59).toInstant(tz).toEpochMilliseconds()
 
             val events = getEventsWithinRangeUseCase(startMillis, endMillis, excludedCalendars)
 
-            val eventsByDayIndex = events.groupBy { event ->
-                ((event.start - startMillis) / MILLIS_PER_DAY).toInt()
+            val eventsByDayIndex = buildMap<Int, MutableList<CalendarEvent>> {
+                events.forEach { event ->
+                    val zone = if (event.allDay) TimeZone.UTC else tz
+                    val startDateTime = Instant.fromEpochMilliseconds(event.start).toLocalDateTime(zone)
+                    val endDateTime = Instant.fromEpochMilliseconds(event.end).toLocalDateTime(zone)
+                    val eventStartDate = startDateTime.date
+                    val rawEndDate = endDateTime.date
+                    val eventEndDate = if (
+                        rawEndDate > eventStartDate &&
+                        endDateTime.time == LocalTime(0, 0)
+                    ) {
+                        rawEndDate.minus(1, DateTimeUnit.DAY)
+                    } else rawEndDate
+
+                    val firstIndex = startDate.daysUntil(eventStartDate).coerceAtLeast(0)
+                    val lastIndex = startDate.daysUntil(eventEndDate).coerceAtMost(gridDays - 1)
+                    if (firstIndex > lastIndex) return@forEach
+                    for (dayIndex in firstIndex..lastIndex) {
+                        getOrPut(dayIndex) { mutableListOf() }.add(event)
+                    }
+                }
             }
 
-            (0 until gridDays.toInt()).map { index ->
+            (0 until gridDays).map { index ->
                 val dayDate = startDate.plus(index, DateTimeUnit.DAY)
                 CalendarDay(
                     date = dayDate,

--- a/calendar/presentation/src/main/java/com/mhss/app/presentation/CalendarViewModel.kt
+++ b/calendar/presentation/src/main/java/com/mhss/app/presentation/CalendarViewModel.kt
@@ -21,6 +21,13 @@ import com.mhss.app.ui.toIntList
 import com.mhss.app.util.date.currentLocalDate
 import com.mhss.app.util.date.formatDateForMapping
 import com.mhss.app.util.date.monthName
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -211,14 +218,37 @@ class CalendarViewModel(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
     private fun loadListEvents() {
         viewModelScope.launch {
-            val events = getAllEventsUseCase(_uiState.value.excludedCalendars) {
-                it.start.formatDateForMapping()
+            val tz = TimeZone.currentSystemDefault()
+            val rawEvents = getAllEventsUseCase(_uiState.value.excludedCalendars) { "" }
+                .values.flatten()
+
+            val byDate = sortedMapOf<LocalDate, MutableList<CalendarEvent>>()
+            rawEvents.forEach { event ->
+                val zone = if (event.allDay) TimeZone.UTC else tz
+                val startDate = Instant.fromEpochMilliseconds(event.start).toLocalDateTime(zone).date
+                val endDateTime = Instant.fromEpochMilliseconds(event.end).toLocalDateTime(zone)
+                val rawEndDate = endDateTime.date
+                val endDate = if (rawEndDate > startDate && endDateTime.time == LocalTime(0, 0))
+                    rawEndDate.minus(1, DateTimeUnit.DAY) else rawEndDate
+                var d = startDate
+                while (d <= endDate) {
+                    byDate.getOrPut(d) { mutableListOf() }.add(event)
+                    d = d.plus(1, DateTimeUnit.DAY)
+                }
             }
-            val months = events.map {
-                it.value.first().start.monthName()
-            }.distinct()
+
+            val events = LinkedHashMap<String, List<CalendarEvent>>()
+            byDate.forEach { (date, list) ->
+                val dayMillis = date.atTime(0, 0).toInstant(tz).toEpochMilliseconds()
+                val sorted = list.sortedBy { ev ->
+                    if (ev.start < dayMillis) dayMillis else ev.start
+                }
+                events[dayMillis.formatDateForMapping()] = sorted
+            }
+            val months = byDate.keys.map { it.monthName() }.distinct()
             _uiState.update { it.copy(events = events, months = months) }
         }
     }


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

Render multi-day calendar events on every day they span

Month view grouped events only by the start day index, so an event running Mon through Thu appeared only on Monday. The grouping now iterates from the event start date through its end date and adds the event to each covered day, using UTC for all-day events (stored as midnight UTC by CalendarContract) to avoid timezone skew that made all-day events appear a day early for users west of UTC.

List view had the same flaw: groupBy keyed each event by its start day only. loadListEvents now expands each event into one entry per day it covers, sorting continuation days as midnight so the event floats to the top per the expected behavior.

Fixes #69, #116, #358

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style (formatting, new lines, etc.)
- [ ] Refactoring (no functional changes, renaming)
- [ ] Other (describe the changes):

## Checklist:

- [x] The PR is to the `dev` branch
- [x] My code follows the style and architecture of the project
- [x] I have performed a self-review of my code
- [x] I have tested the app on an actual Android device and everything works as expected
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas (no, but changes is very simple)
