### PR TITLE
Fix/datepicker utc offset

### DIFF
--- a/core/ui/src/main/java/com/mhss/app/ui/components/common/DateTimeDialog.kt
+++ b/core/ui/src/main/java/com/mhss/app/ui/components/common/DateTimeDialog.kt
@@ -28,6 +28,7 @@ import com.mhss.app.ui.R
 import com.mhss.app.util.date.at
 import com.mhss.app.util.date.hour
 import com.mhss.app.util.date.minute
+import com.mhss.app.util.date.utcDateAt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,7 +55,7 @@ fun DateTimeDialog(
                 onClick = {
                     if (showTime) {
                         onDatePicked(
-                            datePickerState.selectedDateMillis?.at(
+                            datePickerState.selectedDateMillis?.utcDateAt(
                                 timePickerState.hour,
                                 timePickerState.minute
                             ) ?: initialDate
@@ -108,7 +109,7 @@ fun DateDialog(
             TextButton(
                 onClick = {
                     onDatePicked(
-                        datePickerState.selectedDateMillis?.at(
+                        datePickerState.selectedDateMillis?.utcDateAt(
                             initialDate.hour,
                             initialDate.minute
                         ) ?: initialDate

--- a/core/util/src/main/java/com/mhss/app/util/date/DateUtils.kt
+++ b/core/util/src/main/java/com/mhss/app/util/date/DateUtils.kt
@@ -199,6 +199,19 @@ fun Long.at(hours: Int, minutes: Int): Long {
     ).toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
 }
 
+fun Long.utcDateAt(hours: Int, minutes: Int): Long {
+    val date = Instant.fromEpochMilliseconds(this).toLocalDateTime(TimeZone.UTC).date
+    return LocalDateTime(
+        year = date.year,
+        month = date.month,
+        day = date.day,
+        hour = hours,
+        minute = minutes,
+        second = 0,
+        nanosecond = 0
+    ).toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds()
+}
+
 fun Long.toDayOfWeek(): DayOfWeek {
     return Instant
         .fromEpochMilliseconds(this)


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue.

Fix date picker off-by-one for users west of UTC

Material3 DatePicker returns selectedDateMillis as UTC midnight of the chosen date. The old code called Long.at(hour, minute), which reinterprets the millis in the local timezone. For users west of UTC that rolls the date back one day (and for users east it shifts the stored time), so picking April 20 saved April 19, and setting a task due date for tomorrow silently reverted to today.

Added Long.utcDateAt(hours, minutes) that reads the year, month, and day in UTC and reassembles a local-timezone instant at the given time. DateDialog and DateTimeDialog now use utcDateAt on the picker output. This affects calendar event start and end dates, task due dates, and diary entries.


Fixes #252, #293, #305
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style (formatting, new lines, etc.)
- [ ] Refactoring (no functional changes, renaming)
- [ ] Other (describe the changes):

## Checklist:

- [x] The PR is to the `dev` branch
- [x] My code follows the style and architecture of the project
- [x] I have performed a self-review of my code
- [x] I have tested the app on an actual Android device and everything works as expected
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas (no, but changes is very simple)
