### PR TITLE
Add Requesty as an AI provider

### DIFF
--- a/ai/data/src/main/java/com/mhss/app/data/LLMUtil.kt
+++ b/ai/data/src/main/java/com/mhss/app/data/LLMUtil.kt
@@ -104,6 +104,7 @@ fun AiProvider.toLLMProvider() = when (this) {
     AiProvider.Gemini -> LLMProvider.Google
     AiProvider.Anthropic -> LLMProvider.Anthropic
     AiProvider.OpenRouter -> LLMProvider.OpenRouter
+    AiProvider.Requesty -> LLMProvider.OpenAI // Requesty is OpenAI-compatible
     AiProvider.Ollama -> LLMProvider.Ollama
     AiProvider.LmStudio -> LLMProvider.OpenAI
     AiProvider.None -> LLMProvider.OpenAI // just a placeholder

--- a/ai/data/src/main/java/com/mhss/app/data/repository/AiRepositoryImpl.kt
+++ b/ai/data/src/main/java/com/mhss/app/data/repository/AiRepositoryImpl.kt
@@ -359,6 +359,12 @@ private fun AiProvider.getExecutor(key: String, customUrl: String, llModel: LLMo
             )
         )
         AiProvider.OpenRouter -> OpenRouterLLMClient(apiKey = key)
+        AiProvider.Requesty -> OpenAILLMClient(
+            apiKey = key,
+            settings = OpenAIClientSettings(
+                baseUrl = if (customUrl.isBlank()) "https://router.requesty.ai/v1" else customUrl
+            )
+        )
         AiProvider.Ollama -> if (customUrl.isBlank()) OllamaClient() else OllamaClient(customUrl)
         AiProvider.LmStudio -> OpenAILLMClient(
             apiKey = "",

--- a/core/preferences/src/main/java/com/mhss/app/preferences/PrefsConstants.kt
+++ b/core/preferences/src/main/java/com/mhss/app/preferences/PrefsConstants.kt
@@ -30,6 +30,8 @@ object PrefsConstants {
     const val ANTHROPIC_KEY = "anthropic_key"
     const val OPEN_ROUTER_MODEL_KEY = "open_router_model"
     const val OPEN_ROUTER_KEY = "open_router_key"
+    const val REQUESTY_MODEL_KEY = "requesty_model"
+    const val REQUESTY_KEY = "requesty_key"
 
     const val LM_STUDIO_MODEL_KEY = "lm_studio_model"
     const val LM_STUDIO_URL_KEY = "lm_studio_url"

--- a/core/preferences/src/main/java/com/mhss/app/preferences/domain/model/AiProvider.kt
+++ b/core/preferences/src/main/java/com/mhss/app/preferences/domain/model/AiProvider.kt
@@ -53,6 +53,15 @@ enum class AiProvider(
         keyInfoUrl = "https://openrouter.ai/keys",
         modelsInfoUrl = "https://openrouter.ai/models"
     ),
+    Requesty(
+        id = 7,
+        keyPref = PrefsConstants.REQUESTY_KEY,
+        modelPref = PrefsConstants.REQUESTY_MODEL_KEY,
+        defaultModel = "openai/gpt-4o-mini",
+        keyInfoUrl = "https://app.requesty.ai/api-keys",
+        modelsInfoUrl = "https://app.requesty.ai/router/list",
+        defaultBaseUrl = "https://router.requesty.ai/v1"
+    ),
     LmStudio(
         id = 5,
         keyPref = null,

--- a/core/ui/src/main/res/drawable/ic_requesty.xml
+++ b/core/ui/src/main/res/drawable/ic_requesty.xml
@@ -1,0 +1,10 @@
+<!-- PLACEHOLDER icon for Requesty provider. Neutral generic AI/API glyph, not the official Requesty brand mark. Replace with the real logo when available. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,2L2,7v10l10,5l10,-5V7L12,2zM12,4.236L19.5,8L12,11.764L4.5,8L12,4.236zM4,9.618l7,3.5v6.264l-7,-3.5V9.618zM13,19.382v-6.264l7,-3.5v6.264L13,19.382z"
+      android:fillColor="#FFFFFF"/>
+</vector>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -206,6 +206,7 @@
     <string name="gemini">Gemini</string>
     <string name="anthropic" translatable="false">Anthropic</string>
     <string name="openrouter" translatable="false">OpenRouter</string>
+    <string name="requesty" translatable="false">Requesty</string>
     <string name="ollama" translatable="false">Ollama</string>
     <string name="lm_studio" translatable="false">LM Studio</string>
     <string name="openai">OpenAI</string>

--- a/settings/presentation/src/main/java/com/mhss/app/presentation/integrations/AiProviderSection.kt
+++ b/settings/presentation/src/main/java/com/mhss/app/presentation/integrations/AiProviderSection.kt
@@ -83,6 +83,11 @@ fun AiProviderSection(
             icon = painterResource(id = R.drawable.ic_openrouter)
         ),
         ProviderOption(
+            provider = AiProvider.Requesty,
+            label = stringResource(R.string.requesty),
+            icon = painterResource(id = R.drawable.ic_requesty)
+        ),
+        ProviderOption(
             provider = AiProvider.LmStudio,
             label = stringResource(R.string.lm_studio),
             icon = painterResource(id = R.drawable.ic_lmstudio)


### PR DESCRIPTION
Adds Requesty as an AI provider, mirroring the existing OpenRouter provider.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth.

Changes:
- `core/preferences/.../domain/model/AiProvider.kt`: a `Requesty` enum entry mirroring `OpenRouter` (unique id, `keyPref`/`modelPref`, `defaultModel = "openai/gpt-4o-mini"` (verified live), `keyInfoUrl = https://app.requesty.ai/api-keys`, `modelsInfoUrl = https://app.requesty.ai/router/list`, `defaultBaseUrl = https://router.requesty.ai/v1`).
- `core/preferences/.../PrefsConstants.kt`: `REQUESTY_KEY` / `REQUESTY_MODEL_KEY`.
- `ai/data/.../LLMUtil.kt` and `AiRepositoryImpl.kt`: Requesty branches in the exhaustive `when (provider)` blocks — mapped to the OpenAI-compatible client with the Requesty base URL (both `when`s are exhaustive, so this is required to compile).
- `settings/.../AiProviderSection.kt`: Requesty option in the provider list.
- `core/ui/.../values/strings.xml`: `requesty` string.
- `core/ui/.../res/drawable/ic_requesty.xml`: placeholder icon (a neutral generic vector, not a Requesty logo) — happy to drop it or swap in the official mark.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.